### PR TITLE
Requester

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"golang.Go"
+		"golang.Go",
+		"eamodio.gitlens"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/endpoint/bench_test.go
+++ b/endpoint/bench_test.go
@@ -3,11 +3,20 @@ package endpoint
 import (
 	//"net/http"
 	//_ "net/http/pprof"
+	"net/http"
+	"strings"
 	"testing"
 )
 
 func Benchmark_Endpoint_Default_Success(b *testing.B) {
 	endpointRunner := createTestEndpoint()
+
+	req, _ := http.NewRequest(http.MethodPost, "/resources/myid/5/true?id=me&num=13&flag=true", strings.NewReader(`{"my_string": "hello", "my_int": 5}`))
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	requester := NewHttpRequester("/resources/{id}/{num}/{flag}", req)
 
 	// go func() {
 	// 	_ = http.ListenAndServe("localhost:6060", nil)
@@ -16,7 +25,7 @@ func Benchmark_Endpoint_Default_Success(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			ctx := newTestContext()
+			ctx := newTestContext(requester)
 			endpointRunner.Execute(ctx)
 		}
 	})
@@ -25,10 +34,17 @@ func Benchmark_Endpoint_Default_Success(b *testing.B) {
 func Benchmark_Endpoint_Default_Error(b *testing.B) {
 	endpointRunner := createTestEndpoint()
 
+	req, _ := http.NewRequest(http.MethodPost, "/resources/myid/5/true?id=me&num=13&flag=true", strings.NewReader(`{"my_string": "hello", "my_int": 5}`))
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	requester := NewHttpRequester("/resources/{id}/{num}/{flag}", req)
+
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			ctx := newTestContext()
+			ctx := newTestContext(requester)
 			endpointRunner.Execute(ctx)
 		}
 	})

--- a/endpoint/context.go
+++ b/endpoint/context.go
@@ -2,39 +2,10 @@ package endpoint
 
 import (
 	"context"
-	"time"
 
 	"github.com/wspowell/errors"
 	"github.com/wspowell/local"
-	"github.com/wspowell/logging"
 )
-
-type Requester interface {
-	RequestId() string
-
-	// HTTP Method.
-	Method() []byte
-	// Path of the actual request URL.
-	Path() []byte
-
-	ContentType() []byte
-	Accept() []byte
-
-	VisitHeaders(f func(key []byte, value []byte))
-
-	// MatchedPath returns the endpoint path that the request URL matches.
-	// Ex: /some/path/{id}
-	MatchedPath() string
-
-	// PathParam returns the path parameter value for the given parameter name.
-	// Returns false if parameter not found.
-	PathParam(param string) (string, bool)
-	QueryParam(param string) []byte
-
-	RequestBody() []byte
-
-	SetResponseContentType(contentType string)
-}
 
 var _ local.Context = (*Context)(nil)
 
@@ -42,30 +13,17 @@ var _ local.Context = (*Context)(nil)
 type Context struct {
 	*local.Localized
 
-	cancel    context.CancelFunc
 	requester Requester
-
-	HttpMethod  []byte
-	MatchedPath string
 }
 
 // NewContext creates a new endpoint context. The server creates this and passes it to the endpoint handler.
-// TODO: It would be really nice if *fasthttp.RequestCtx could be replaced with an interface. Not sure if this is possible.
-func NewContext(serverContext context.Context, requester Requester, timeout time.Duration) *Context {
+func NewContext(serverContext context.Context, requester Requester) *Context {
 	ctx := local.FromContext(serverContext)
-	cancel := local.WithTimeout(ctx, timeout)
 
 	return &Context{
 		Localized: ctx,
-		cancel:    cancel,
 		requester: requester,
 	}
-}
-
-// Cancels the endpoint execution.
-// Only call this when you need to cancel execution of child goroutines.
-func (self *Context) Cancel() {
-	self.cancel()
 }
 
 // ShouldContinue returns true if the underlying request has not been cancelled nor deadline exceeded.
@@ -73,17 +31,4 @@ func (self *Context) ShouldContinue() bool {
 	err := self.Context.Err()
 
 	return !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded))
-}
-
-// NewTestContext is an endpoint context setup for testing.
-func NewTestContext(requester Requester) *Context {
-	ctx := context.Background()
-	serverContext := local.FromContext(ctx)
-
-	logConfig := logging.NewConfig(logging.LevelInfo)
-	logConfig.Tags()["test"] = true
-
-	logging.WithContext(serverContext, logConfig)
-
-	return NewContext(serverContext, requester, 30*time.Second)
 }

--- a/endpoint/context_test.go
+++ b/endpoint/context_test.go
@@ -6,18 +6,12 @@ import (
 	"time"
 
 	"github.com/wspowell/errors"
-
-	"github.com/valyala/fasthttp"
 )
 
 func Test_Context_DeadlineExceeded(t *testing.T) {
 	t.Parallel()
 
-	var req fasthttp.Request
-	requestCtx := fasthttp.RequestCtx{}
-	requestCtx.Init(&req, nil, nil)
-
-	ctx := NewContext(context.Background(), &requestCtx, time.Millisecond)
+	ctx := NewContext(context.Background(), nil, time.Millisecond)
 
 	time.Sleep(time.Second)
 
@@ -37,11 +31,7 @@ func Test_Context_DeadlineExceeded(t *testing.T) {
 func Test_Context_Canceled(t *testing.T) {
 	t.Parallel()
 
-	var req fasthttp.Request
-	requestCtx := fasthttp.RequestCtx{}
-	requestCtx.Init(&req, nil, nil)
-
-	ctx := NewContext(context.Background(), &requestCtx, 30*time.Second)
+	ctx := NewContext(context.Background(), nil, 30*time.Second)
 
 	ctx.Cancel()
 

--- a/endpoint/context_test.go
+++ b/endpoint/context_test.go
@@ -11,7 +11,10 @@ import (
 func Test_Context_DeadlineExceeded(t *testing.T) {
 	t.Parallel()
 
-	ctx := NewContext(context.Background(), nil, time.Millisecond)
+	endpointCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	ctx := NewContext(endpointCtx, nil)
 
 	time.Sleep(time.Second)
 
@@ -31,9 +34,11 @@ func Test_Context_DeadlineExceeded(t *testing.T) {
 func Test_Context_Canceled(t *testing.T) {
 	t.Parallel()
 
-	ctx := NewContext(context.Background(), nil, 30*time.Second)
+	endpointCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
-	ctx.Cancel()
+	ctx := NewContext(endpointCtx, nil)
+
+	cancel()
 
 	if ctx.ShouldContinue() {
 		t.Errorf("ShouldContinue() should have returned false")

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -20,10 +20,6 @@ const (
 	structTagOptionValidate = "validate"
 )
 
-const (
-	HeaderAccept = "Accept"
-)
-
 var (
 	nullBytes = []byte("null")
 )
@@ -108,16 +104,16 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 	{
 		// Every invocation of an endpoint is guaranteed to get its own logger instance.
 		// See: logging.WithContext()
-		logging.Tag(ctx, "request_id", ctx.requestCtx.ID())
-		logging.Tag(ctx, "method", string(ctx.requestCtx.Method()))
-		logging.Tag(ctx, "route", ctx.MatchedPath)
-		logging.Tag(ctx, "path", string(ctx.requestCtx.URI().Path()))
+		logging.Tag(ctx, "request_id", ctx.requester.RequestId())
+		logging.Tag(ctx, "method", string(ctx.requester.Method()))
+		logging.Tag(ctx, "route", ctx.requester.MatchedPath())
+		logging.Tag(ctx, "path", string(ctx.requester.Path()))
 		logging.Tag(ctx, "action", self.Name())
 
 		// Each path parameter is added as a log tag.
 		// Note: It helps if the path parameter name is descriptive.
 		for param := range self.handlerData.pathParameters {
-			if value, ok := ctx.requestCtx.UserValue(param).(string); ok {
+			if value, ok := ctx.requester.PathParam(param); ok {
 				logging.Tag(ctx, param, value)
 			}
 		}
@@ -135,7 +131,7 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 		if self.handlerData.hasRequestBody {
 			logging.Trace(ctx, "processing request body mime type")
 
-			contentType := ctx.Request().Header.ContentType()
+			contentType := ctx.requester.ContentType()
 			if len(contentType) == 0 {
 				logging.Debug(ctx, "header Content-Type not found")
 				return self.processErrorResponse(ctx, responseMimeType, http.StatusUnsupportedMediaType, errors.New(InternalCodeRequestMimeTypeMissing, "Content-Type MIME type not provided"))
@@ -153,7 +149,7 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 		if self.handlerData.hasResponseBody {
 			logging.Trace(ctx, "processing response body mime type")
 
-			accept := ctx.Request().Header.Peek(HeaderAccept)
+			accept := ctx.requester.Accept()
 			if len(accept) == 0 {
 				logging.Debug(ctx, "header Accept not found")
 				return self.processErrorResponse(ctx, responseMimeType, http.StatusUnsupportedMediaType, errors.New(InternalCodeResponseMimeTypeMissing, "Accept MIME type not provided"))
@@ -165,7 +161,7 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 				return self.processErrorResponse(ctx, responseMimeType, http.StatusUnsupportedMediaType, errors.New(InternalCodeResponseMimeTypeUnsupported, "Accept MIME type not supported: %s", accept))
 			}
 			// All responses after this must be marshalable to the mime type.
-			ctx.requestCtx.SetContentType(responseMimeType.MimeType)
+			ctx.requester.SetResponseContentType(responseMimeType.MimeType)
 
 			logging.Debug(ctx, "found response mime type handler: %s", accept)
 		}
@@ -183,7 +179,7 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 		if self.Config.Auther != nil {
 			logging.Trace(ctx, "processing auth handler")
 
-			httpStatus, err = self.Config.Auther.Auth(ctx, ctx.Request().Header.VisitAll)
+			httpStatus, err = self.Config.Auther.Auth(ctx, ctx.requester.VisitHeaders)
 			authTimer.Finish()
 			if err != nil {
 				logging.Debug(ctx, "auth failed")
@@ -203,8 +199,8 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 	handlerAlloc := self.handlerData.allocateHandler()
 
 	self.handlerData.setResources(handlerAlloc.handlerValue, self.Config.Resources)
-	self.handlerData.setPathParameters(handlerAlloc.handlerValue, ctx.requestCtx)
-	self.handlerData.setQueryParameters(handlerAlloc.handlerValue, ctx.requestCtx)
+	self.handlerData.setPathParameters(handlerAlloc.handlerValue, ctx.requester)
+	self.handlerData.setQueryParameters(handlerAlloc.handlerValue, ctx.requester)
 	allocateTimer.Finish()
 
 	// Handle Request
@@ -217,7 +213,7 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 		if self.handlerData.hasRequestBody {
 			logging.Trace(ctx, "processing request body")
 
-			requestBodyBytes := ctx.Request().Body()
+			requestBodyBytes := ctx.requester.RequestBody()
 
 			populateRequestTimer := profiling.Profile(ctx, "UnmarshalRequest")
 			err = self.setHandlerRequestBody(ctx, requestMimeType, handlerAlloc.requestBody, requestBodyBytes)
@@ -316,7 +312,7 @@ func (self *Endpoint) processErrorResponse(ctx *Context, responseMimeType *MimeT
 	}
 
 	if responseMimeType == nil {
-		ctx.requestCtx.SetContentType(mimeTypeTextPlain)
+		ctx.requester.SetResponseContentType(mimeTypeTextPlain)
 		responseBody = []byte(fmt.Sprintf("%#v", err))
 		return httpStatus, responseBody
 	}
@@ -324,7 +320,7 @@ func (self *Endpoint) processErrorResponse(ctx *Context, responseMimeType *MimeT
 	httpStatus, errStruct = self.Config.ErrorHandler.HandleError(ctx, httpStatus, err)
 	responseBody, err = responseMimeType.Marshal(errStruct)
 	if err != nil {
-		ctx.requestCtx.SetContentType(mimeTypeTextPlain)
+		ctx.requester.SetResponseContentType(mimeTypeTextPlain)
 		err = errors.New(InternalCodeErrorParseFailure, "Internal server error")
 		httpStatus = http.StatusInternalServerError
 		responseBody = []byte(fmt.Sprintf("%s", err))
@@ -350,7 +346,7 @@ func (self *Endpoint) getHandlerResponseBody(ctx *Context, mimeHandler *MimeType
 	if responseBody != nil {
 		logging.Trace(ctx, "non-empty response body")
 
-		ctx.requestCtx.SetContentType(mimeHandler.MimeType)
+		ctx.requester.SetResponseContentType(mimeHandler.MimeType)
 		responseBodyBytes, err := mimeHandler.Marshal(responseBody)
 		if err != nil {
 			logging.Error(ctx, "failed to marshal response: %v", err)

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -98,7 +98,9 @@ func (self *Endpoint) Execute(ctx *Context) (httpStatus int, responseBody []byte
 		}
 	}()
 
-	defer profiling.Profile(ctx, string(ctx.HttpMethod)+" "+ctx.MatchedPath).Finish()
+	defer profiling.Profile(ctx, string(ctx.requester.Method())+" "+ctx.requester.MatchedPath()).Finish()
+
+	ctx.requester.SetResponseHeader("X-Request-Id", ctx.requester.RequestId())
 
 	// Setup logging.
 	{

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -3,16 +3,14 @@ package endpoint
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+	"strings"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/wspowell/errors"
 	"github.com/wspowell/local"
 	"github.com/wspowell/logging"
-
-	"github.com/valyala/fasthttp"
 )
 
 type errorResponse struct {
@@ -91,39 +89,39 @@ func (self *myEndpoint) Handle(ctx *Context) (int, error) {
 	logging.Debug(ctx, "handling myEndpoint")
 
 	if self.RequestBody.ShouldFail {
-		return http.StatusUnprocessableEntity, errors.New("APP1234", "invalid input")
+		return http.StatusUnprocessableEntity, errors.New("APP1", "invalid input")
 	}
 
-	if self.MyStringQuery != "myid" {
-		return http.StatusInternalServerError, errors.New("APP1111", "string query param not set")
+	if self.MyStringQuery != "me" {
+		return http.StatusInternalServerError, errors.New("APP2", "string query param not set")
 	}
 
 	if self.MyIntQuery != 13 {
-		return http.StatusInternalServerError, errors.New("APP1111", "int query param not set")
+		return http.StatusInternalServerError, errors.New("APP3", "int query param not set")
 	}
 
 	if self.MyBoolQuery != true {
-		return http.StatusInternalServerError, errors.New("APP1111", "bool query param not set")
+		return http.StatusInternalServerError, errors.New("APP4", "bool query param not set")
 	}
 
 	if self.MyStringParam != "myid" {
-		return http.StatusInternalServerError, errors.New("APP1111", "string path param not set")
+		return http.StatusInternalServerError, errors.New("APP5", "string path param not set")
 	}
 
 	if self.MyIntParam != 5 {
-		return http.StatusInternalServerError, errors.New("APP1111", "int path param not set")
+		return http.StatusInternalServerError, errors.New("APP6", "int path param not set")
 	}
 
 	if self.MyFlagParam != true {
-		return http.StatusInternalServerError, errors.New("APP1111", "bool path param not set")
+		return http.StatusInternalServerError, errors.New("APP7", "bool path param not set")
 	}
 
 	if self.MyDatabase == nil {
-		return http.StatusInternalServerError, errors.New("APP1111", "database not set")
+		return http.StatusInternalServerError, errors.New("APP8", "database not set")
 	}
 
 	if self.MyDatabase.Conn() != "myconnection" {
-		return http.StatusInternalServerError, errors.New("APP1111", "database connection error")
+		return http.StatusInternalServerError, errors.New("APP9", "database connection error")
 	}
 
 	self.ResponseBody = &myResponseBodyModel{
@@ -170,45 +168,34 @@ func createDefaultTestEndpoint() *Endpoint {
 	return NewEndpoint(config, &myEndpoint{})
 }
 
-func newTestContext() *Context {
-	var req fasthttp.Request
-
-	//req.Header.SetMethod(method)
-	req.Header.SetRequestURI("/resources/myid?id=myid&num=13&flag=true")
-	req.Header.Set(fasthttp.HeaderHost, "localhost")
-	req.Header.Set(fasthttp.HeaderUserAgent, "")
-	req.Header.Set("Authorization", "auth-token")
-	req.Header.SetContentType("application/json")
-	req.Header.Set("Accept", "application/json")
-	req.SetBody([]byte(`{"my_string": "hello", "my_int": 5}`))
-
-	requestCtx := fasthttp.RequestCtx{}
-	requestCtx.Init(&req, nil, nil)
-
-	requestCtx.SetUserValue("id", "myid")
-	requestCtx.SetUserValue("num", "5")
-	requestCtx.SetUserValue("flag", "true")
-
+func newTestContext(req Requester) *Context {
 	logConfig := logging.NewConfig(logging.LevelError)
 	ctx := local.NewLocalized()
 	logging.WithContext(ctx, logConfig)
 
-	return NewContext(ctx, &requestCtx, 30*time.Second)
+	return NewContext(ctx, req)
 }
 
 func Test_Endpoint_Success(t *testing.T) {
 	t.Parallel()
 
 	endpoint := createTestEndpoint()
-	ctx := newTestContext()
+
+	req, err := http.NewRequest(http.MethodPost, "/resources/myid/5/true?id=me&num=13&flag=true", strings.NewReader(`{"my_string": "hello", "my_int": 5}`))
+	assert.Nil(t, err)
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	requester := NewHttpRequester("/resources/{id}/{num}/{flag}", req)
+
+	ctx := newTestContext(requester)
 
 	httpStatus, responseBodyBytes := endpoint.Execute(ctx)
 
 	if http.StatusOK != httpStatus {
 		t.Errorf("expected HTTP status code to be %v, but got %v", http.StatusOK, httpStatus)
 	}
-
-	fmt.Println(string(responseBodyBytes))
 
 	var responseBody myResponseBodyModel
 	if err := json.Unmarshal(responseBodyBytes, &responseBody); err != nil {
@@ -228,15 +215,22 @@ func Test_Endpoint_Default_Success(t *testing.T) {
 	t.Parallel()
 
 	endpoint := createDefaultTestEndpoint()
-	ctx := newTestContext()
+
+	req, err := http.NewRequest(http.MethodPost, "/resources/myid/5/true?id=me&num=13&flag=true", strings.NewReader(`{"my_string": "hello", "my_int": 5}`))
+	assert.Nil(t, err)
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	requester := NewHttpRequester("/resources/{id}/{num}/{flag}", req)
+
+	ctx := newTestContext(requester)
 
 	httpStatus, responseBodyBytes := endpoint.Execute(ctx)
 
 	if http.StatusOK != httpStatus {
 		t.Errorf("expected HTTP status code to be %v, but got %v", http.StatusOK, httpStatus)
 	}
-
-	fmt.Println(string(responseBodyBytes))
 
 	var responseBody myResponseBodyModel
 	if err := json.Unmarshal(responseBodyBytes, &responseBody); err != nil {
@@ -256,8 +250,17 @@ func Test_Endpoint_Error(t *testing.T) {
 	t.Parallel()
 
 	endpoint := createTestEndpoint()
-	ctx := newTestContext()
-	ctx.Request().SetBody([]byte(`{"my_string": "hello", "my_int": 5, "fail": true}`))
+
+	req, err := http.NewRequest(http.MethodPost, "/resources/myid/5/true?id=me&num=13&flag=true", strings.NewReader(`{"my_string": "hello", "my_int": 5, "fail": true}`))
+	assert.Nil(t, err)
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	requester := NewHttpRequester("/resources/{id}/{num}/{flag}", req)
+
+	ctx := newTestContext(requester)
+
 	httpStatus, responseBodyBytes := endpoint.Execute(ctx)
 
 	if http.StatusUnprocessableEntity != httpStatus {
@@ -271,8 +274,8 @@ func Test_Endpoint_Error(t *testing.T) {
 		t.Errorf("failed to unmarshal test response: %v", err)
 	}
 
-	if "[APP1234] invalid input" != responseBody.Message {
-		t.Errorf("expected 'message' to be '%v', but got '%v'", "[APP1234] invalid input", responseBody.Message)
+	if "[APP1] invalid input" != responseBody.Message {
+		t.Errorf("expected 'message' to be '%v', but got '%v'", "[APP1] invalid input", responseBody.Message)
 	}
 }
 
@@ -280,75 +283,24 @@ func Test_Endpoint_Default_Error(t *testing.T) {
 	t.Parallel()
 
 	endpoint := createDefaultTestEndpoint()
-	ctx := newTestContext()
-	ctx.Request().SetBody([]byte(`{"my_string": "hello", "my_int": 5, "fail": true}`))
+
+	req, err := http.NewRequest(http.MethodPost, "/resources/myid/5/true?id=me&num=13&flag=true", strings.NewReader(`{"my_string": "hello", "my_int": 5, "fail": true}`))
+	assert.Nil(t, err)
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	requester := NewHttpRequester("/resources/{id}/{num}/{flag}", req)
+
+	ctx := newTestContext(requester)
+
 	httpStatus, responseBodyBytes := endpoint.Execute(ctx)
 
 	if http.StatusUnprocessableEntity != httpStatus {
 		t.Errorf("expected HTTP status code to be %v, but got %v", http.StatusOK, httpStatus)
 	}
 
-	if `{"message":"[APP1234] invalid input"}` != string(responseBodyBytes) {
-		t.Errorf("expected 'message' to be '%v', but got '%v'", "[APP1234] invalid input", string(responseBodyBytes))
+	if `{"message":"[APP1] invalid input"}` != string(responseBodyBytes) {
+		t.Errorf("expected 'message' to be '%v', but got '%v'", "[APP1] invalid input", string(responseBodyBytes))
 	}
-}
-
-type httpRequester struct {
-	request   *http.Request
-	bodyBytes []byte
-}
-
-func newHttpRequester(request *http.Request) *httpRequester {
-	bodyBytes, _ := io.ReadAll(request.Body)
-
-	return &httpRequester{
-		request:   request,
-		bodyBytes: bodyBytes,
-	}
-}
-
-func (self *httpRequester) RequestId() string {
-	return "abc-123"
-}
-
-func (self *httpRequester) Method() []byte {
-	return []byte(self.request.Method)
-}
-
-func (self *httpRequester) Path() []byte {
-	return []byte(self.request.URL.Path)
-}
-
-func (self *httpRequester) ContentType() []byte {
-	return []byte(self.request.Header.Get("Content-Type"))
-}
-
-func (self *httpRequester) Accept() []byte {
-	return []byte(self.request.Header.Get("Accept"))
-}
-
-func (self *httpRequester) VisitHeaders(f func(key []byte, value []byte)) {
-	for header, value := range self.request.Header {
-		f([]byte(header), []byte(value[0]))
-	}
-}
-
-func (self *httpRequester) MatchedPath() string {
-	return ""
-}
-
-func (self *httpRequester) PathParam(param string) (string, bool) {
-	return "", true
-}
-
-func (self *httpRequester) QueryParam(param string) []byte {
-	return []byte(self.request.URL.Query().Get(param))
-}
-
-func (self *httpRequester) RequestBody() []byte {
-	return self.bodyBytes
-}
-
-func (self *httpRequester) SetResponseContentType(contentType string) {
-	// noop
 }

--- a/endpoint/http_requester.go
+++ b/endpoint/http_requester.go
@@ -1,0 +1,125 @@
+package endpoint
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+type Requester interface {
+	RequestId() string
+
+	// HTTP Method.
+	Method() []byte
+	// Path of the actual request URL.
+	Path() []byte
+
+	ContentType() []byte
+	Accept() []byte
+
+	VisitHeaders(f func(key []byte, value []byte))
+
+	// MatchedPath returns the endpoint path that the request URL matches.
+	// Ex: /some/path/{id}
+	MatchedPath() string
+
+	// PathParam returns the path parameter value for the given parameter name.
+	// Returns false if parameter not found.
+	PathParam(param string) (string, bool)
+	QueryParam(param string) ([]byte, bool)
+
+	RequestBody() []byte
+
+	SetResponseHeader(header string, value string)
+	SetResponseContentType(contentType string)
+	ResponseContentType() string
+}
+
+var _ Requester = (*HttpRequester)(nil)
+
+type HttpRequester struct {
+	matchedPath string
+	request     *http.Request
+	bodyBytes   []byte
+}
+
+func NewHttpRequester(matchedPath string, request *http.Request) *HttpRequester {
+	var bodyBytes []byte
+	if request.Body != nil {
+		bodyBytes, _ = io.ReadAll(request.Body)
+	}
+
+	request.Response = &http.Response{
+		Header: http.Header{},
+	}
+
+	return &HttpRequester{
+		matchedPath: matchedPath,
+		request:     request,
+		bodyBytes:   bodyBytes,
+	}
+}
+
+func (self *HttpRequester) RequestId() string {
+	return "abc-123"
+}
+
+func (self *HttpRequester) Method() []byte {
+	return []byte(self.request.Method)
+}
+
+func (self *HttpRequester) Path() []byte {
+	return []byte(self.request.URL.Path)
+}
+
+func (self *HttpRequester) ContentType() []byte {
+	return []byte(self.request.Header.Get("Content-Type"))
+}
+
+func (self *HttpRequester) Accept() []byte {
+	return []byte(self.request.Header.Get("Accept"))
+}
+
+func (self *HttpRequester) VisitHeaders(f func(key []byte, value []byte)) {
+	for header, value := range self.request.Header {
+		f([]byte(header), []byte(value[0]))
+	}
+}
+
+func (self *HttpRequester) MatchedPath() string {
+	return self.matchedPath
+}
+
+func (self *HttpRequester) PathParam(param string) (string, bool) {
+	urlParts := strings.Split(self.request.URL.Path, "/")
+	pathParts := strings.Split(self.matchedPath, "/")
+
+	for index, value := range pathParts {
+		if value == "{"+param+"}" {
+			return urlParts[index], true
+		}
+	}
+
+	return "", false
+}
+
+func (self *HttpRequester) QueryParam(param string) ([]byte, bool) {
+	value := self.request.URL.Query().Get(param)
+	return []byte(value), value != ""
+}
+
+func (self *HttpRequester) RequestBody() []byte {
+	return self.bodyBytes
+}
+
+func (self *HttpRequester) SetResponseHeader(header string, value string) {
+	self.request.Response.Header.Set(header, value)
+}
+
+func (self *HttpRequester) SetResponseContentType(contentType string) {
+	self.request.Response.Header.Set("Content-Type", contentType)
+}
+
+func (self *HttpRequester) ResponseContentType() string {
+	return self.request.Response.Header.Get("Content-Type")
+}

--- a/endpoint/reflection.go
+++ b/endpoint/reflection.go
@@ -4,8 +4,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/valyala/fasthttp"
 )
 
 // This file contains all the reflection that is not nice to look at.
@@ -241,7 +239,7 @@ func (self handlerTypeData) setResources(handlerValue reflect.Value, resources m
 	}
 }
 
-func (self handlerTypeData) setPathParameters(handlerValue reflect.Value, requestCtx *fasthttp.RequestCtx) {
+func (self handlerTypeData) setPathParameters(handlerValue reflect.Value, requester Requester) {
 	for param, fieldNum := range self.pathParameters {
 
 		parameterValue := handlerValue.Elem().Field(fieldNum)
@@ -250,7 +248,7 @@ func (self handlerTypeData) setPathParameters(handlerValue reflect.Value, reques
 			continue
 		}
 
-		value, ok := requestCtx.UserValue(param).(string)
+		value, ok := requester.PathParam(param)
 		if !ok {
 			continue
 		}
@@ -259,7 +257,7 @@ func (self handlerTypeData) setPathParameters(handlerValue reflect.Value, reques
 	}
 }
 
-func (self handlerTypeData) setQueryParameters(handlerValue reflect.Value, requestCtx *fasthttp.RequestCtx) {
+func (self handlerTypeData) setQueryParameters(handlerValue reflect.Value, requester Requester) {
 	for query, fieldNum := range self.queryParameters {
 		queryValue := handlerValue.Elem().Field(fieldNum)
 
@@ -267,7 +265,7 @@ func (self handlerTypeData) setQueryParameters(handlerValue reflect.Value, reque
 			continue
 		}
 
-		queryBytes := requestCtx.URI().QueryArgs().Peek(query)
+		queryBytes := requester.QueryParam(query)
 
 		setValueFromString(queryValue, string(queryBytes))
 	}

--- a/endpoint/reflection.go
+++ b/endpoint/reflection.go
@@ -265,7 +265,10 @@ func (self handlerTypeData) setQueryParameters(handlerValue reflect.Value, reque
 			continue
 		}
 
-		queryBytes := requester.QueryParam(query)
+		queryBytes, ok := requester.QueryParam(query)
+		if !ok {
+			continue
+		}
 
 		setValueFromString(queryValue, string(queryBytes))
 	}

--- a/examples/lambda/lambdas/foo/create/event.json
+++ b/examples/lambda/lambdas/foo/create/event.json
@@ -19,7 +19,7 @@
         "baz": "qux"
     },
     "headers": {
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate, sdch",
         "Accept-Language": "en-US,en;q=0.8",
         "Cache-Control": "max-age=0",
@@ -29,6 +29,7 @@
         "CloudFront-Is-SmartTV-Viewer": "false",
         "CloudFront-Is-Tablet-Viewer": "false",
         "CloudFront-Viewer-Country": "US",
+        "Content-Type": "application/json",
         "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
         "Upgrade-Insecure-Requests": "1",
         "User-Agent": "Custom User Agent String",

--- a/examples/lambda/lambdas/foo/create/lambda.go
+++ b/examples/lambda/lambdas/foo/create/lambda.go
@@ -14,6 +14,6 @@ func main() {
 		Timeout:   30 * time.Second,
 	}
 
-	handler := lambda.New(config, &create{})
+	handler := lambda.New(config, "/foo", &create{})
 	handler.Start()
 }

--- a/examples/lambda/lambdas/foo/get/event.json
+++ b/examples/lambda/lambdas/foo/get/event.json
@@ -19,7 +19,7 @@
         "baz": "qux"
     },
     "headers": {
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate, sdch",
         "Accept-Language": "en-US,en;q=0.8",
         "Cache-Control": "max-age=0",
@@ -29,6 +29,7 @@
         "CloudFront-Is-SmartTV-Viewer": "false",
         "CloudFront-Is-Tablet-Viewer": "false",
         "CloudFront-Viewer-Country": "US",
+        "Content-Type": "application/json",
         "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
         "Upgrade-Insecure-Requests": "1",
         "User-Agent": "Custom User Agent String",

--- a/examples/lambda/lambdas/foo/get/lambda.go
+++ b/examples/lambda/lambdas/foo/get/lambda.go
@@ -14,6 +14,6 @@ func main() {
 		Timeout:   30 * time.Second,
 	}
 
-	handler := lambda.New(config, &get{})
+	handler := lambda.New(config, "/foo", &get{})
 	handler.Start()
 }

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gotest.tools v2.1.0+incompatible // indirect
-	gotest.tools/gotestsum v1.6.3 // indirect
+	gotest.tools/gotestsum v1.6.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -127,4 +127,6 @@ gotest.tools v2.1.0+incompatible h1:5USw7CrJBYKqjg9R7QlA6jzqZKEAtvW82aNmsxxGPxw=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v1.6.3 h1:E3wOF4wmxKA19BB5wTY7t0L1m+QNARtDcBX4yqG6DEc=
 gotest.tools/gotestsum v1.6.3/go.mod h1:fTR9ZhxC/TLAAx2/WMk/m3TkMB9eEI89gdEzhiRVJT8=
+gotest.tools/gotestsum v1.6.4 h1:HFkapG0hK/HWiOxWS78SbR/JK5EpbH8hFzUuCvvfbfQ=
+gotest.tools/gotestsum v1.6.4/go.mod h1:fTR9ZhxC/TLAAx2/WMk/m3TkMB9eEI89gdEzhiRVJT8=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/lambda/api_gateway_requester.go
+++ b/lambda/api_gateway_requester.go
@@ -1,0 +1,93 @@
+package lambda
+
+import (
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type ApiGatewayRequester struct {
+	matchedPath string
+	request     *events.APIGatewayProxyRequest
+	bodyBytes   []byte
+
+	responseHeaders map[string]string
+}
+
+func NewApiGatewayRequester(matchedPath string, request *events.APIGatewayProxyRequest) *ApiGatewayRequester {
+	var bodyBytes []byte
+	if request.Body != "" {
+		bodyBytes = []byte(request.Body)
+	}
+
+	return &ApiGatewayRequester{
+		matchedPath:     matchedPath,
+		request:         request,
+		bodyBytes:       bodyBytes,
+		responseHeaders: map[string]string{},
+	}
+}
+
+func (self *ApiGatewayRequester) RequestId() string {
+	return self.request.RequestContext.RequestID
+}
+
+func (self *ApiGatewayRequester) Method() []byte {
+	return []byte(self.request.HTTPMethod)
+}
+
+func (self *ApiGatewayRequester) Path() []byte {
+	return []byte(self.request.Path)
+}
+
+func (self *ApiGatewayRequester) ContentType() []byte {
+	return []byte(self.request.Headers["Content-Type"])
+}
+
+func (self *ApiGatewayRequester) Accept() []byte {
+	return []byte(self.request.Headers["Accept"])
+}
+
+func (self *ApiGatewayRequester) VisitHeaders(f func(key []byte, value []byte)) {
+	for header, value := range self.request.Headers {
+		f([]byte(header), []byte(value))
+	}
+}
+
+func (self *ApiGatewayRequester) MatchedPath() string {
+	return self.matchedPath
+}
+
+func (self *ApiGatewayRequester) PathParam(param string) (string, bool) {
+	urlParts := strings.Split(self.request.Path, "/")
+	pathParts := strings.Split(self.matchedPath, "/")
+
+	for index, value := range pathParts {
+		if value == "{"+param+"}" {
+			return urlParts[index], true
+		}
+	}
+
+	return "", false
+}
+
+func (self *ApiGatewayRequester) QueryParam(param string) ([]byte, bool) {
+	value, exists := self.request.QueryStringParameters[param]
+	return []byte(value), exists
+}
+
+func (self *ApiGatewayRequester) RequestBody() []byte {
+	return self.bodyBytes
+}
+
+func (self *ApiGatewayRequester) SetResponseHeader(header string, value string) {
+	self.responseHeaders[header] = value
+}
+
+func (self *ApiGatewayRequester) SetResponseContentType(contentType string) {
+	self.responseHeaders["Content-Type"] = contentType
+}
+
+func (self *ApiGatewayRequester) ResponseContentType() string {
+	return self.responseHeaders["Content-Type"]
+}

--- a/lambda/lambda.go
+++ b/lambda/lambda.go
@@ -2,15 +2,11 @@ package lambda
 
 import (
 	"context"
-	"net/http"
 
-	"github.com/wspowell/local"
-	"github.com/wspowell/logging"
 	"github.com/wspowell/spiderweb/endpoint"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/valyala/fasthttp"
 )
 
 // FIXME: Should be able to handle any event, not just API Gateway.
@@ -18,17 +14,14 @@ import (
 type HandlerAPIGateway func(context.Context, events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)
 
 type Lambda struct {
-	lambdaContext  context.Context
+	matchedPath    string
 	endpointConfig *endpoint.Config
 	routeEndpoint  *endpoint.Endpoint
 }
 
-func New(endpointConfig *endpoint.Config, handler endpoint.Handler) *Lambda {
-	ctx := local.NewLocalized()
-	logging.WithContext(ctx, endpointConfig.LogConfig)
-
+func New(endpointConfig *endpoint.Config, matchedPath string, handler endpoint.Handler) *Lambda {
 	return &Lambda{
-		lambdaContext:  ctx,
+		matchedPath:    matchedPath,
 		endpointConfig: endpointConfig,
 		routeEndpoint:  endpoint.NewEndpoint(endpointConfig, handler),
 	}
@@ -53,49 +46,20 @@ func (self *Lambda) Start() {
 func (self *Lambda) wrapLambdaHandler(routeEndpoint *endpoint.Endpoint) HandlerAPIGateway {
 	return func(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 		response := events.APIGatewayProxyResponse{}
+		requester := NewApiGatewayRequester(self.matchedPath, &request)
 
-		// FIXME: This should be able to execute without fasthttp.
-		var req fasthttp.Request
+		ctx, cancel := context.WithTimeout(ctx, self.endpointConfig.Timeout)
+		go func() {
+			<-ctx.Done()
+			cancel()
+		}()
 
-		req.Header.SetMethod(request.HTTPMethod)
-		req.Header.SetRequestURI(request.Path)
-		for header, value := range request.Headers {
-			req.Header.Set(header, value)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept", "application/json")
-		req.SetBody([]byte(request.Body))
+		endpointCtx := endpoint.NewContext(ctx, requester)
+		httpStatus, responseBody := routeEndpoint.Execute(endpointCtx)
 
-		requestCtx := &fasthttp.RequestCtx{}
-		requestCtx.Init(&req, nil, nil)
-
-		fasthttp.TimeoutWithCodeHandler(func(fasthttpCtx *fasthttp.RequestCtx) {
-			// Every invocation of an endpoint is guaranteed to get its own logger instance.
-			var logger logging.Logger = self.endpointConfig.LogConfig.Logger()
-
-			logger.Tag("request_id", fasthttpCtx.ID())
-			logger.Tag("route", request.HTTPMethod+" "+request.Resource)
-
-			// Note: The endpoint context must receive the same timeout as the fasthttp.TimeoutWithCodeHandler or this will cause unexpected behavior.
-			ctx := endpoint.NewContext(self.lambdaContext, fasthttpCtx, self.endpointConfig.Timeout)
-			httpStatus, responseBody := routeEndpoint.Execute(ctx)
-
-			fasthttpCtx.SetStatusCode(httpStatus)
-			fasthttpCtx.SetBody(responseBody)
-
-			headers := map[string]string{}
-			fasthttpCtx.Response.Header.VisitAll(func(key []byte, value []byte) {
-				headers[string(key)] = string(value)
-			})
-
-			response.Body = string(responseBody)
-			response.StatusCode = httpStatus
-			response.Headers = headers
-
-			// Set the Connection header to "close".
-			// Closes the connection after this function returns.
-			fasthttpCtx.Response.SetConnectionClose()
-		}, self.endpointConfig.Timeout, "", http.StatusRequestTimeout)(requestCtx)
+		response.Body = string(responseBody)
+		response.StatusCode = httpStatus
+		response.Headers = requester.responseHeaders
 
 		return response, nil
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -15,6 +16,10 @@ import (
 
 	"github.com/fasthttp/router"
 	"github.com/valyala/fasthttp"
+)
+
+const (
+	headerAccept = "Accept"
 )
 
 // Config top level options.
@@ -75,7 +80,7 @@ func New(serverConfig *Config) *Server {
 }
 
 func (self *Server) HandleNotFound(endpointConfig *endpoint.Config, handler endpoint.Handler) {
-	requestHandler := fasthttp.TimeoutWithCodeHandler(func(fasthttpCtx *fasthttp.RequestCtx) {
+	requestHandler := fasthttp.TimeoutWithCodeHandler(func(requestCtx *fasthttp.RequestCtx) {
 		// Every invocation of an endpoint is guaranteed to get its own logger instance.
 		var logger logging.Logger
 		if endpointConfig != nil {
@@ -83,20 +88,20 @@ func (self *Server) HandleNotFound(endpointConfig *endpoint.Config, handler endp
 		} else {
 			logger = self.serverConfig.LogConfig.Logger()
 		}
-		logger.Tag("request_id", fasthttpCtx.ID())
+		logger.Tag("request_id", requestCtx.ID())
 		logger.Tag("route", "NOT FOUND")
 
 		// Note: The endpoint context must receive the same timeout as the fasthttp.TimeoutWithCodeHandler or this will cause unexpected behavior.
-		ctx := endpoint.NewContext(self.serverContext, fasthttpCtx, endpointConfig.Timeout)
+		ctx := endpoint.NewContext(self.serverContext, newFasthttpRequester(requestCtx), endpointConfig.Timeout)
 		routeEndpoint := endpoint.NewEndpoint(endpointConfig, handler)
 		httpStatus, responseBody := routeEndpoint.Execute(ctx)
 
-		fasthttpCtx.SetStatusCode(httpStatus)
-		fasthttpCtx.SetBody(responseBody)
+		requestCtx.SetStatusCode(httpStatus)
+		requestCtx.SetBody(responseBody)
 
 		// Set the Connection header to "close".
 		// Closes the connection after this function returns.
-		fasthttpCtx.Response.SetConnectionClose()
+		requestCtx.Response.SetConnectionClose()
 	}, endpointConfig.Timeout, "", http.StatusRequestTimeout)
 
 	self.router.NotFound = requestHandler
@@ -188,16 +193,73 @@ func (self *Server) wrapFasthttpHandler(endpointConfig *endpoint.Config, httpMet
 
 	// Wrapping the handler in a timeout will force a timeout response.
 	// This does not stop the endpoint from running. The endpoint itself will need to check if it should continue.
-	return fasthttp.TimeoutWithCodeHandler(func(fasthttpCtx *fasthttp.RequestCtx) {
+	return fasthttp.TimeoutWithCodeHandler(func(requestCtx *fasthttp.RequestCtx) {
 		// Note: The endpoint context must receive the same timeout as the fasthttp.TimeoutWithCodeHandler or this will cause unexpected behavior.
-		ctx := endpoint.NewContext(self.serverContext, fasthttpCtx, endpointConfig.Timeout)
+		ctx := endpoint.NewContext(self.serverContext, newFasthttpRequester(requestCtx), endpointConfig.Timeout)
 		httpStatus, responseBody := routeEndpoint.Execute(ctx)
 
-		fasthttpCtx.SetStatusCode(httpStatus)
-		fasthttpCtx.SetBody(responseBody)
+		requestCtx.SetStatusCode(httpStatus)
+		requestCtx.SetBody(responseBody)
 
 		// Set the Connection header to "close".
 		// Closes the connection after this function returns.
-		fasthttpCtx.Response.SetConnectionClose()
+		requestCtx.Response.SetConnectionClose()
 	}, endpointConfig.Timeout, "", http.StatusRequestTimeout)
+}
+
+type fasthttpRequester struct {
+	requestCtx *fasthttp.RequestCtx
+}
+
+func newFasthttpRequester(requestCtx *fasthttp.RequestCtx) *fasthttpRequester {
+	return &fasthttpRequester{
+		requestCtx: requestCtx,
+	}
+}
+
+func (self *fasthttpRequester) RequestId() string {
+	return strconv.Itoa(int(self.requestCtx.ID()))
+}
+
+func (self *fasthttpRequester) Method() []byte {
+	return self.requestCtx.Method()
+}
+
+func (self *fasthttpRequester) Path() []byte {
+	return self.requestCtx.URI().Path()
+}
+
+func (self *fasthttpRequester) ContentType() []byte {
+	return self.requestCtx.Request.Header.ContentType()
+}
+
+func (self *fasthttpRequester) Accept() []byte {
+	return self.requestCtx.Request.Header.Peek(headerAccept)
+}
+
+func (self *fasthttpRequester) VisitHeaders(f func(key []byte, value []byte)) {
+	self.requestCtx.Request.Header.VisitAll(f)
+}
+
+func (self *fasthttpRequester) MatchedPath() string {
+	var matchedPath string
+	matchedPath, _ = self.requestCtx.UserValue(router.MatchedRoutePathParam).(string)
+	return matchedPath
+}
+
+func (self *fasthttpRequester) PathParam(param string) (string, bool) {
+	value, ok := self.requestCtx.UserValue(param).(string)
+	return value, ok
+}
+
+func (self *fasthttpRequester) QueryParam(param string) []byte {
+	return self.requestCtx.URI().QueryArgs().Peek(param)
+}
+
+func (self *fasthttpRequester) RequestBody() []byte {
+	return self.requestCtx.Request.Body()
+}
+
+func (self *fasthttpRequester) SetResponseContentType(contentType string) {
+	self.requestCtx.SetContentType(contentType)
 }

--- a/server/servertest/endpoint.go
+++ b/server/servertest/endpoint.go
@@ -1,6 +1,7 @@
 package servertest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
 	"github.com/wspowell/spiderweb/endpoint"
 )
 
@@ -25,16 +27,17 @@ func handlerFuzzTest(t *testing.T, handler endpoint.Handler) {
 	// The endpoint is never handed a struct with nil values so set nil chance to 0.
 	f := fuzz.New().NilChance(0)
 
-	endpointContext := endpoint.NewTestContext()
+	endpointContext := endpoint.NewContext(context.Background(), nil)
 	for i := 0; i < 100; i++ {
 		f.Fuzz(handler)
-		handler.Handle(endpointContext)
+		_, err := handler.Handle(endpointContext)
+		assert.Nil(t, err)
 	}
 }
 
 // TestEndpoint for business logic.
 func TestEndpoint(t *testing.T, input endpoint.Handler, expected endpoint.Handler, expectedHttpStatus int, expectedError error) {
-	endpointContext := endpoint.NewTestContext()
+	endpointContext := endpoint.NewContext(context.Background(), nil)
 
 	httpStatus, err := input.Handle(endpointContext)
 


### PR DESCRIPTION
Refactor endpoint to use Requester interface. This allows two key things:
* Lambda code no longer requires a fasthttp.RequestCtx
* Endpoints can now execute using any http framework. A framework just needs to implement Requester to pass into the endpoint.Context.